### PR TITLE
Stravalib 2.0

### DIFF
--- a/backend/constants.py
+++ b/backend/constants.py
@@ -1,3 +1,6 @@
+import typing
+from stravalib import model
+
 class ActivityTypes:
     """
     This class acts as a dictionary of the possible activity types
@@ -13,3 +16,5 @@ class ActivityTypes:
     NORDICSKI = 'NordicSki'
     FRAME_TYPES = {0: "", 1: MTB, 3: ROAD, 2: CX, 4: TT, 5: GRAVEL}
     ACTIVITY_TYPES = {HIKE, RUN, RIDE, ROAD, MTB, CX, TT, NORDICSKI}
+    SPORT_TYPES = typing.get_args(model.RelaxedSportType.model_fields['root'].annotation)
+

--- a/backend/constants.py
+++ b/backend/constants.py
@@ -15,6 +15,6 @@ class ActivityTypes:
     RUN = 'Run'
     NORDICSKI = 'NordicSki'
     FRAME_TYPES = {0: "", 1: MTB, 3: ROAD, 2: CX, 4: TT, 5: GRAVEL}
-    ACTIVITY_TYPES = {HIKE, RUN, RIDE, ROAD, MTB, CX, TT, NORDICSKI}
+    ACTIVITY_TYPES = typing.get_args(model.RelaxedActivityType.model_fields['root'].annotation)
     SPORT_TYPES = typing.get_args(model.RelaxedSportType.model_fields['root'].annotation)
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,79 +1,72 @@
 import sqlalchemy as db
 from sqlalchemy.ext.declarative import declarative_base
-from backend import config
 from backend.constants import ActivityTypes
 
 Base = declarative_base()
 
-def make_gear_model(tablename):
-    class GearModel(Base):
-        __tablename__ = tablename
-        id = db.Column(db.String(45), primary_key=True)
-        name = db.Column(db.String(256), nullable=True)
-        type = db.Column(db.Enum(ActivityTypes.HIKE, ActivityTypes.RUN, ActivityTypes.ROAD, ActivityTypes.MTB, ActivityTypes.CX, ActivityTypes.TT, ActivityTypes.GRAVEL), nullable=True)
-        frame_type = db.Column(db.Integer, default=0)
-        athlete = db.Column(db.Integer, default=0)
-        retired = db.Column(db.Boolean, default=False)
+class Gear(Base):
+    __tablename__ = "gears"
+    id = db.Column(db.String(45), primary_key=True)
+    name = db.Column(db.String(256), nullable=True)
+    type = db.Column(db.Enum(ActivityTypes.HIKE, ActivityTypes.RUN, ActivityTypes.ROAD, ActivityTypes.MTB, ActivityTypes.CX, ActivityTypes.TT, ActivityTypes.GRAVEL), nullable=True)
+    frame_type = db.Column(db.Integer, default=0)
+    athlete = db.Column(db.Integer, default=0)
+    retired = db.Column(db.Boolean, default=False)
 
-        def to_json(self):
-            return {
-                "id": self.id,
-                "name": self.name,
-                "type": self.type,
-                "frame_type": self.frame_type,
-                "athlete": self.athlete,
-                "retired": self.retired
-            }
+    def to_json(self):
+        return {
+            "id": self.id,
+            "name": self.name,
+            "type": self.type,
+            "frame_type": self.frame_type,
+            "athlete": self.athlete,
+            "retired": self.retired
+        }
 
-    return GearModel
 
-def make_activity_model(tablename):
-    class ActivityModel(Base):
-        __tablename__ = tablename
-        id = db.Column(db.BigInteger, primary_key=True)
-        athlete = db.Column(db.Integer, default=0)
-        name = db.Column(db.String(256), default='') # COLLATE utf8mb4_bin DEFAULT NULL,
-        location = db.Column(db.String(256), default='')
-        date = db.Column(db.DateTime, nullable=True)
-        distance = db.Column(db.Float, default=0)
-        elevation = db.Column(db.Float, default=0)
-        moving_time = db.Column(db.Time, default=0)
-        elapsed_time = db.Column(db.Time, default=0)
-        gear_id = db.Column(db.String(45), default='')
-        average_speed = db.Column(db.Float, default=0)
-        max_heartrate = db.Column(db.Integer, default=0)
-        average_heartrate = db.Column(db.Float, default=0)
-        suffer_score = db.Column(db.Integer, default=0)
-        red_points = db.Column(db.Integer, default=0)
-        description = db.Column(db.Text, default='') # COLLATE utf8mb4_bin DEFAULT NULL,
-        commute = db.Column(db.Boolean, default=False)
-        calories = db.Column(db.Float, default=0)
-        type = db.Column(db.Enum(ActivityTypes.RIDE, ActivityTypes.RUN, ActivityTypes.HIKE, ActivityTypes.NORDICSKI), default='')
+class Activity(Base):
+    __tablename__ = "activities"
+    id = db.Column(db.BigInteger, primary_key=True)
+    athlete = db.Column(db.Integer, default=0)
+    name = db.Column(db.String(256), default='') # COLLATE utf8mb4_bin DEFAULT NULL,
+    location = db.Column(db.String(256), default='')
+    date = db.Column(db.DateTime, nullable=True)
+    distance = db.Column(db.Float, default=0)
+    elevation = db.Column(db.Float, default=0)
+    moving_time = db.Column(db.Time, default=0)
+    elapsed_time = db.Column(db.Time, default=0)
+    gear_id = db.Column(db.String(45), default='')
+    average_speed = db.Column(db.Float, default=0)
+    max_heartrate = db.Column(db.Integer, default=0)
+    average_heartrate = db.Column(db.Float, default=0)
+    suffer_score = db.Column(db.Integer, default=0)
+    red_points = db.Column(db.Integer, default=0)
+    description = db.Column(db.Text, default='') # COLLATE utf8mb4_bin DEFAULT NULL,
+    commute = db.Column(db.Boolean, default=False)
+    calories = db.Column(db.Float, default=0)
+    type = db.Column(db.Enum(ActivityTypes.RIDE, ActivityTypes.RUN, ActivityTypes.HIKE, ActivityTypes.NORDICSKI), default='')
+    sport_type = db.Column(db.Enum(*ActivityTypes.SPORT_TYPES), default='')
 
-        def to_json(self):
-            return {
-                "id": self.id,
-                "athlete": self.athlete,
-                "name": self.name,
-                "location": self.location,
-                "date": self.date.strftime("%Y-%m-%d"),
-                "distance": self.distance,
-                "elevation": self.elevation,
-                "moving_time": self.moving_time.strftime("%H:%M"),
-                "elapsed_time": self.elapsed_time.strftime("%H:%M"),
-                "gear_id": self.gear_id,
-                "average_speed": self.average_speed,
-                "max_heartrate": self.max_heartrate,
-                "average_heartrate": self.average_heartrate,
-                "suffer_score": self.suffer_score,
-                "red_points": self.red_points,
-                "description": self.description if self.description is not None else '',
-                "commute": self.commute,
-                "calories": self.calories,
-                "activity_type": self.type
-            }
-
-    return ActivityModel
-
-Gear = make_gear_model(config['mysql_bikes_table'])
-Activity = make_activity_model(config['mysql_activities_table'])
+    def to_json(self):
+        return {
+            "id": self.id,
+            "athlete": self.athlete,
+            "name": self.name,
+            "location": self.location,
+            "date": self.date.strftime("%Y-%m-%d"),
+            "distance": self.distance,
+            "elevation": self.elevation,
+            "moving_time": self.moving_time.strftime("%H:%M"),
+            "elapsed_time": self.elapsed_time.strftime("%H:%M"),
+            "gear_id": self.gear_id,
+            "average_speed": self.average_speed,
+            "max_heartrate": self.max_heartrate,
+            "average_heartrate": self.average_heartrate,
+            "suffer_score": self.suffer_score,
+            "red_points": self.red_points,
+            "description": self.description if self.description is not None else '',
+            "commute": self.commute,
+            "calories": self.calories,
+            "activity_type": self.type,
+            "sport_type": self.sport_type
+        }

--- a/backend/models.py
+++ b/backend/models.py
@@ -44,7 +44,7 @@ class Activity(Base):
     description = db.Column(db.Text, default='') # COLLATE utf8mb4_bin DEFAULT NULL,
     commute = db.Column(db.Boolean, default=False)
     calories = db.Column(db.Float, default=0)
-    type = db.Column(db.Enum(ActivityTypes.RIDE, ActivityTypes.RUN, ActivityTypes.HIKE, ActivityTypes.NORDICSKI), default='')
+    type = db.Column(db.Enum(*ActivityTypes.ACTIVITY_TYPES), default='')
     sport_type = db.Column(db.Enum(*ActivityTypes.SPORT_TYPES), default='')
 
     def to_json(self):

--- a/backend/models.py
+++ b/backend/models.py
@@ -40,7 +40,7 @@ class Activity(Base):
     max_heartrate = db.Column(db.Integer, default=0)
     average_heartrate = db.Column(db.Float, default=0)
     suffer_score = db.Column(db.Integer, default=0)
-    red_points = db.Column(db.Integer, default=0)
+    red_points = db.Column(db.Integer, default=0) # Deprecated
     description = db.Column(db.Text, default='') # COLLATE utf8mb4_bin DEFAULT NULL,
     commute = db.Column(db.Boolean, default=False)
     calories = db.Column(db.Float, default=0)

--- a/backend/readconfig.py
+++ b/backend/readconfig.py
@@ -32,18 +32,6 @@ def read_config(infile):
         sys.exit()
 
     try:
-        config['mysql_bikes_table'] = parser.get('mysql', 'bikes_table')
-    except configparser.NoOptionError:
-        print("No name provided for the bikes table")
-        sys.exit()
-
-    try:
-        config['mysql_activities_table'] = parser.get('mysql', 'activities_table')
-    except configparser.NoOptionError:
-        print("No name provided for the activities table")
-        sys.exit()
-
-    try:
         config['client_id'] = parser.get('strava', 'client_id')
     except configparser.NoOptionError:
         print("No Strava client id provided")

--- a/backend/readconfig.py
+++ b/backend/readconfig.py
@@ -44,14 +44,9 @@ def read_config(infile):
         sys.exit()
 
     try:
-        config['with_points'] = parser.getboolean('strava', 'with_points')
+        config['with_details'] = parser.getboolean('strava', 'with_details')
     except (configparser.NoOptionError, ValueError):
-        config['with_points'] = False
-
-    try:
-        config['with_description'] = parser.getboolean('strava', 'with_description')
-    except (configparser.NoOptionError, ValueError):
-        config['with_description'] = False
+        config['with_details'] = False
 
     try:
         config['session_dir'] = parser.get('server', 'session_dir')

--- a/backend/server/serve.py
+++ b/backend/server/serve.py
@@ -269,3 +269,9 @@ class StravaUI:
         print("-------")
 
         raise cherrypy.HTTPRedirect(cherrypy.url(path='/', script_name=''))
+
+    @cherrypy.expose
+    def updatesporttype(self):
+        stravaRequest = StravaRequest(self.config, self._getOrRefreshToken())
+        view = StravaView(self.config, cherrypy.session.get(self.ATHLETE_ID))
+        view.fix_sport_type_all_activities(stravaRequest)

--- a/backend/server/serve.py
+++ b/backend/server/serve.py
@@ -5,6 +5,7 @@ import time
 import cherrypy
 import stravalib
 import requests
+import stravalib.model
 
 from backend.stravadb import StravaRequest, StravaView
 
@@ -186,8 +187,8 @@ class StravaUI:
         if isinstance(activity_id, str):
             activity_id = int(activity_id)
         try:
-            activity = stravaRequest.client.get_activity(activity_id)
-            view.update_new_activities(activity, stravaRequest)
+            activity: stravalib.model.DetailedActivity = stravaRequest.client.get_activity(activity_id)
+            view.update_activity(activity, stravaRequest)
             activity = view.get_activities(list_ids=activity_id)
         except requests.exceptions.HTTPError:
             # Page not found. Probably a deleted activity.

--- a/backend/server/serve.py
+++ b/backend/server/serve.py
@@ -146,7 +146,7 @@ class StravaUI:
         cherrypy.session[self.DUMMY] = 'MyStravaUpdateActivities'
         view = StravaView(self.config, cherrypy.session.get(self.ATHLETE_ID))
         stravaRequest = StravaRequest(self.config, self._getOrRefreshToken())
-        list_ids = view.update_activities(stravaRequest)
+        list_ids = view.update_new_activities(stravaRequest)
         activities = view.get_activities(list_ids=list_ids)
         view.close()
         return activities
@@ -187,7 +187,7 @@ class StravaUI:
             activity_id = int(activity_id)
         try:
             activity = stravaRequest.client.get_activity(activity_id)
-            view.update_activity(activity, stravaRequest)
+            view.update_new_activities(activity, stravaRequest)
             activity = view.get_activities(list_ids=activity_id)
         except requests.exceptions.HTTPError:
             # Page not found. Probably a deleted activity.

--- a/backend/server/serve.py
+++ b/backend/server/serve.py
@@ -271,7 +271,7 @@ class StravaUI:
         raise cherrypy.HTTPRedirect(cherrypy.url(path='/', script_name=''))
 
     @cherrypy.expose
-    def updatesporttype(self):
+    def updatesporttype(self,trail_seuil):
         stravaRequest = StravaRequest(self.config, self._getOrRefreshToken())
         view = StravaView(self.config, cherrypy.session.get(self.ATHLETE_ID))
-        view.fix_sport_type_all_activities(stravaRequest)
+        view.fix_sport_type_all_activities(stravaRequest, trail_seuil)

--- a/backend/stravadb.py
+++ b/backend/stravadb.py
@@ -45,8 +45,7 @@ class StravaRequest:
         """
         self.token = token
         self.client = stravalib.Client(access_token=token)
-        self.with_points = config['with_points']
-        self.with_description = config['with_description']
+        self.with_details = config['with_details']
         self.client_id = config['client_id']
         self.client_secret = config['client_secret']
 
@@ -58,40 +57,6 @@ class StravaRequest:
             self.athlete = None
             self.athlete_id = 0
             self.athlete_profile = ""
-
-    def get_points(self, activity: stravalib.model.SummaryActivity):
-        """
-        Request the points for an activity
-
-        :param activity: a Strava activity
-        :type activity: Activity
-        """
-
-        if ((not self.with_points) or (activity.suffer_score is None)):
-            return 0
-        try:
-            zones = activity.zones
-            if not zones:
-                return 0
-            for z in zones:
-                if z.type == 'heartrate':
-                    return z.points
-        except:
-            return 0
-        return 0
-
-    def get_description(self, activity: stravalib.model.SummaryActivity):
-        """
-        Request the description of an activity
-
-        :param activity: a Strava activity
-        :type activity: Activity
-        """
-        if not self.with_description:
-            return None
-        detailed_activity = self.client.get_activity(activity.id)
-        description = detailed_activity.description
-        return description
 
 
 class StravaView:

--- a/backend/stravadb.py
+++ b/backend/stravadb.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 
 import stravalib.client
 import stravalib.model
-import stravalib.unithelper
+import stravalib.unit_helper
 import sqlalchemy
 
 from backend.constants import ActivityTypes
@@ -166,7 +166,7 @@ class StravaView:
             old_activity.gear_id = activity.gear_id
             old_activity.commute = activity.commute
             if activity.total_elevation_gain is not None:
-                elevation = "%0.0f" % stravalib.unithelper.meters(activity.total_elevation_gain).num
+                elevation = "%0.0f" % stravalib.unit_helper.meters(activity.total_elevation_gain).num
                 old_activity.elevation = elevation
             self.session.commit()
             print(f"Activity {activity.name.encode('utf-8')} was already in the local db. Updated.")
@@ -189,15 +189,15 @@ class StravaView:
         # Get the real values
         athlete_id = activity.athlete.id
         if activity.distance is not None:
-            distance = "%0.2f" % stravalib.unithelper.kilometers(activity.distance).num
+            distance = "%0.2f" % stravalib.unit_helper.kilometers(activity.distance).num
         if activity.total_elevation_gain is not None:
-            elevation = "%0.0f" % stravalib.unithelper.meters(activity.total_elevation_gain).num
+            elevation = "%0.0f" % stravalib.unit_helper.meters(activity.total_elevation_gain).num
         date = activity.start_date_local
         moving_time = activity.moving_time
         elapsed_time = activity.elapsed_time
         gear_id = activity.gear_id
         if activity.average_speed is not None:
-            average_speed = "%0.1f" % stravalib.unithelper.kilometers_per_hour(activity.average_speed).num
+            average_speed = "%0.1f" % stravalib.unit_helper.kilometers_per_hour(activity.average_speed).num
         if activity.average_heartrate is not None:
             average_heartrate = "%0.0f" % activity.average_heartrate
             max_heartrate = activity.max_heartrate

--- a/backend/stravadb.py
+++ b/backend/stravadb.py
@@ -153,11 +153,11 @@ class StravaView:
         self.session.commit()
 
 
-    def push_activity(self, activity):
+    def push_activity(self, activity: stravalib.model.DetailedActivity):
         """
         Add the activity `activity` to the activities table
 
-        :param activity: an object of class:`stravalib.model.Activity`
+        :param activity: an object of class:`stravalib.model.DetailedActivity`
         """
         # Check if activity is already in the table
         old_activity = self.session.query(Activity).filter_by(id=activity.id).first()
@@ -212,7 +212,7 @@ class StravaView:
         self.session.add(new_activity)
         self.session.commit()
 
-    def update_activity_extra_fields(self, activity, stravaRequest):
+    def update_activity_extra_fields(self, activity: stravalib.model.DetailedActivity, stravaRequest: StravaRequest):
         """
         Update a given activity already in the local db
 
@@ -238,7 +238,7 @@ class StravaView:
         self.session.commit()
         print(f"Update the description, points and location of activity {activity.id}.")
 
-    def update_activity(self, activity, stravaRequest):
+    def update_activity(self, activity: stravalib.model.DetailedActivity, stravaRequest: StravaRequest):
         """
         Update a given activity already in the local db
 
@@ -263,7 +263,7 @@ class StravaView:
         self.session.commit()
         print("Activity deleted")
 
-    def update_activities(self, stravaRequest):
+    def update_activities(self, stravaRequest: StravaRequest):
         """
         Fetch new activities and push into the local db.
 
@@ -286,7 +286,7 @@ class StravaView:
             self.update_activity_extra_fields(activity, stravaRequest)
         return list_ids
 
-    def rebuild_activities(self, stravaRequest):
+    def rebuild_activities(self, stravaRequest: StravaRequest):
         """
         Get the whole list of activities from Strava and updates the local db accordingly.
         The activities already in the local db are updated if needed.

--- a/backend/stravadb.py
+++ b/backend/stravadb.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from __future__ import print_function
 
 import stravalib.client
@@ -62,7 +59,7 @@ class StravaRequest:
             self.athlete_id = 0
             self.athlete_profile = ""
 
-    def get_points(self, activity):
+    def get_points(self, activity: stravalib.model.SummaryActivity):
         """
         Request the points for an activity
 
@@ -83,7 +80,7 @@ class StravaRequest:
             return 0
         return 0
 
-    def get_description(self, activity):
+    def get_description(self, activity: stravalib.model.SummaryActivity):
         """
         Request the description of an activity
 
@@ -170,7 +167,7 @@ class StravaView:
         self.session.commit()
 
 
-    def push_activity(self, activity: stravalib.model.DetailedActivity):
+    def push_activity(self, activity: stravalib.model.SummaryActivity):
         """
         Add the activity `activity` to the activities table
 
@@ -185,7 +182,7 @@ class StravaView:
             old_activity.type = activity.type
             old_activity.sport_type = activity.sport_type
             if activity.total_elevation_gain is not None:
-                elevation = "%0.0f" % stravalib.unit_helper.meters(activity.total_elevation_gain).num
+                elevation = f"{stravalib.unit_helper.meters(activity.total_elevation_gain).magnitude:.0f}"
                 old_activity.elevation = elevation
             self.session.commit()
             print(f"Activity {activity.name.encode('utf-8')} was already in the local db. Updated.")
@@ -204,17 +201,17 @@ class StravaView:
         # Get the real values
         athlete_id = activity.athlete.id
         if activity.distance is not None:
-            distance = "%0.2f" % stravalib.unit_helper.kilometers(activity.distance).num
+            distance = f"{stravalib.unit_helper.kilometers(activity.distance).magnitude:.2f}"
         if activity.total_elevation_gain is not None:
-            elevation = "%0.0f" % stravalib.unit_helper.meters(activity.total_elevation_gain).num
+            elevation = f"{stravalib.unit_helper.meters(activity.total_elevation_gain).magnitude:.0f}"
         date = activity.start_date_local
         moving_time = activity.moving_time
         elapsed_time = activity.elapsed_time
         gear_id = activity.gear_id
         if activity.average_speed is not None:
-            average_speed = "%0.1f" % stravalib.unit_helper.kilometers_per_hour(activity.average_speed).num
+            average_speed = f"{stravalib.unit_helper.kilometers_per_hour(activity.average_speed).magnitude:.1f}"
         if activity.average_heartrate is not None:
-            average_heartrate = "%0.0f" % activity.average_heartrate
+            average_heartrate = f"{activity.average_heartrate:.0f}"
             max_heartrate = activity.max_heartrate
             if activity.suffer_score is not None:
                 suffer_score = activity.suffer_score
@@ -228,7 +225,7 @@ class StravaView:
         self.session.add(new_activity)
         self.session.commit()
 
-    def update_activity_extra_fields(self, activity: stravalib.model.DetailedActivity, stravaRequest: StravaRequest):
+    def update_activity_extra_fields(self, activity: stravalib.model.SummaryActivity, stravaRequest: StravaRequest):
         """
         Update a given activity already in the local db
 
@@ -254,7 +251,7 @@ class StravaView:
         self.session.commit()
         print(f"Update the description, points and location of activity {activity.id}.")
 
-    def update_activity(self, activity: stravalib.model.DetailedActivity, stravaRequest: StravaRequest):
+    def update_activity(self, activity: stravalib.model.SummaryActivity, stravaRequest: StravaRequest):
         """
         Update a given activity already in the local db
 

--- a/frontend/app/app.js
+++ b/frontend/app/app.js
@@ -1,5 +1,3 @@
-// vim: set sw=4 ts=4 sts=4:
-
 // Make the table height responsive
 $(function() {
     $(window).on('resize', function() {
@@ -63,18 +61,108 @@ var RUNS = 6;
 var HIKES = 7;
 var NORDICSKI = 8;
 
+// Sport_type selector
+var sportTypes = [
+    "All",
+    "AllRides",
+    "AllFootSports",
+    "AlpineSki",
+    "BackcountrySki",
+    "Badminton",
+    "Canoeing",
+    "Crossfit",
+    "EBikeRide",
+    "Elliptical",
+    "EMountainBikeRide",
+    "Golf",
+    "GravelRide",
+    "Handcycle",
+    "HighIntensityIntervalTraining",
+    "Hike",
+    "IceSkate",
+    "InlineSkate",
+    "Kayaking",
+    "Kitesurf",
+    "MountainBikeRide",
+    "NordicSki",
+    "Pickleball",
+    "Pilates",
+    "Racquetball",
+    "Ride",
+    "RockClimbing",
+    "RollerSki",
+    "Rowing",
+    "Run",
+    "Sail",
+    "Skateboard",
+    "Snowboard",
+    "Snowshoe",
+    "Soccer",
+    "Squash",
+    "StairStepper",
+    "StandUpPaddling",
+    "Surfing",
+    "Swim",
+    "TableTennis",
+    "Tennis",
+    "TrailRun",
+    "Velomobile",
+    "VirtualRide",
+    "VirtualRow",
+    "VirtualRun",
+    "Walk",
+    "WeightTraining",
+    "Wheelchair",
+    "Windsurf",
+    "Workout",
+    "Yoga"
+];
+
+var allRides = [
+    "EBikeRide",
+    "EMountainBikeRide",
+    "GravelRide",
+    "MountainBikeRide",
+    "Ride",
+    "VirtualRide"
+];
+
+var allFootSports = [
+    "Hike",
+    "Ride",
+    "Run",
+    "TrailRun",
+    "VirtualRun",
+    "Walk"
+];
+
+var allSportWithPace = allFootSports.concat(['NordicSki'])
+
 
 // This filter handles both the activity type and the commute selector
 function selectActivityTypeFilter() {
-    return function (items, activityTypeId, withCommutes) {
+    return function (items, activityType, withCommutes) {
         var retArray = [];
-        if (activityTypeId.id == ALL_ACTIVITIES && withCommutes) {
+        if (activityType.id == 'All' && withCommutes) {
             return items;
         }
         angular.forEach(items, function (obj) {
-            // activityTypeId can either be an activity type or a bike type because we use a flat selector
-            if (((activityTypeId.id == ALL_ACTIVITIES) || (obj.bike_type == activityTypeId.label || obj.activity_type == activityTypeId.label)) && (withCommutes || !obj.commute)) {
-                retArray.push(obj);
+            if (activityType.id == 'All') {
+                if (withCommutes || !obj.commute) {
+                    retArray.push(obj);
+                }
+            } else if (activityType.id == 'AllRides') {
+                if (allRides.includes(obj.sport_type) && (withCommutes || !obj.commute)) {
+                    retArray.push(obj);
+                }
+            } else if (activityType.id == 'AllFootSports') {
+                if (allFootSports.includes(obj.sport_type) && (withCommutes || !obj.commute)) {
+                    retArray.push(obj);
+                }
+            } else {
+                if (obj.sport_type == activityType.id && (withCommutes || !obj.commute)) {
+                    retArray.push(obj);
+                }
             }
         });
         return retArray;
@@ -113,18 +201,11 @@ function StravaController($cookies, $scope, $window, $http, $timeout) {
     vm.speedOrPace = "Speed";
     vm.alternate_tab = null;
 
-    // The labels must match the ones used in stravadb.ActivityTypes
-    vm.activityTypes = [
-        { 'id': ALL_ACTIVITIES, 'label': 'All' },
-        { 'id': ALL_RIDES, 'label': 'Ride' },
-        { 'id': MTB_RIDES, 'label': 'MTB' },
-        { 'id': ROAD_RIDES, 'label': 'Road' },
-        { 'id': GRAVEL_RIDES, 'label': 'Gravel' },
-        { 'id': HIKES, 'label': 'Hike' },
-        { 'id': RUNS, 'label': 'Run' },
-        { 'id': NORDICSKI, 'label': 'NordicSki' },
-    ];
-    vm.activityType = vm.activityTypes[0];
+    // The labels must match the ones used in ActivityType.SPORT_TYPES
+    vm.activityTypes = sportTypes.map(value => {
+        return {'id': value, 'label': value}
+    })
+    vm.activityType = vm.activityTypes[0]; // All activities
     vm.GEARS = 'Gears'
     vm.ACTIVITIES = 'Activities'
     vm.gearsOrActivities = vm.ACTIVITIES;
@@ -193,7 +274,7 @@ function StravaController($cookies, $scope, $window, $http, $timeout) {
     /// @param activities is an array of activities
     function addPacetoActivities(activities) {
         angular.forEach(activities, (activity) => {
-            if (activity.activity_type == 'Run' | activity.activity_type == 'Hike' | activity.activity_type == 'NordicSki') {
+            if (allSportWithPace.includes(activity.sport_type)) {
                 if (activity.average_speed > 0) {
                     var pace = 60.0 / activity.average_speed; // pace in minutes
                     var minutes = Math.floor(pace);
@@ -403,7 +484,7 @@ function StravaController($cookies, $scope, $window, $http, $timeout) {
 
 
     function updateSelectedActivityType() {
-        if (vm.activityType.id == HIKES || vm.activityType.id == RUNS || vm.activityType.id == NORDICSKI) {
+        if (allSportWithPace.includes(vm.activityType.id)) {
             vm.speedOrPace = "Pace";
             vm.getSpeedOrPace = vm.getPace;
         } else {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -115,7 +115,7 @@
                                 <th ng-click="vm.setSort('name');" class="c-name"><div class="c1">Name</div></th>
                                 <th ng-click="vm.setSort('location');" class="c-location"><div class="c2">Location</div></th>
                                 <th ng-click="vm.setSort('date');"  class="c-date"><div class="c3">Date</div></th>
-                                <th ng-click="vm.setSort('bike_type');" class="c-rtype"><div class="c4">Activity</div></th>
+                                <th ng-click="vm.setSort('sport_type');" class="c-rtype"><div class="c4">Activity</div></th>
                                 <th ng-click="vm.setSort('distance');" class="c-int"><div class="c5">Km</div></th>
                                 <th ng-click="vm.setSort('elevation');" class="c-int"><div class="c6">D+</div></th>
                                 <th ng-click="vm.setSort('moving_time');" class="c-time"><div class="c7">Time</div></th>
@@ -132,13 +132,11 @@
                                 </td>
                                 <td>{{data.location}}</td>
                                 <td>{{data.date}}</td>
-                                <td>{{data.bike_type || data.activity_type }}</td>
+                                <td>{{data.sport_type}}</td>
                                 <td>{{data.distance}}</td>
                                 <td>{{data.elevation}}</td>
                                 <td>{{data.moving_time}}</td>
                                 <td ng-switch=vm.activityType.label>
-                                    <!-- <div ng-switch-when="Run|Hike" ng-switch-when-separator="|">{{data.average_pace}}</div>
-                                    <div ng-switch-default>{{data.average_speed}}</div> -->
                                     {{vm.getSpeedOrPace(data)}}
                                 </td>
                                 <td ng-show="vm.isPremium">{{data.suffer_score}}</td>
@@ -192,7 +190,7 @@
                     <thead>
                         <tr>
                             <th ng-click="vm.setSort('name');" class="c-name"><div class="c1">Name</div></th>
-                            <th ng-click="vm.setSort('activity_type');" class="c-rtype"><div class="c4">Activity</div></th>
+                            <th ng-click="vm.setSort('sport_type');" class="c-rtype"><div class="c4">Activity</div></th>
                             <th ng-click="vm.setSort('distance');" class="c-int"><div class="c5">Km</div></th>
                             <th ng-click="vm.setSort('elevation');" class="c-int"><div class="c6">D+</div></th>
                             <th class="c-int"><div class="c6">D+/km</div></th>
@@ -201,7 +199,7 @@
                     <tbody>
                         <tr ng-repeat="data in gears = (vm.gears | filter:vm.searchGear | selectGearFilter: vm.withRetiredGear | orderBy : vm.sortable(vm.predicate) : vm.reverse)">
                             <td>{{data.name}}</td>
-                            <td>{{data.activity_type}}</td>
+                            <td>{{data.sport_type}}</td>
                             <td>{{data.distance}}</td>
                             <td>{{data.elevation}}</td>
                             <td>{{data.elevation / data.distance | number:2}}</td>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ configparser
 geopy==2.4.1
 sqlalchemy
 pymysql
-stravalib
+stravalib==2.0
 cherrypy
 certifi

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ configparser
 geopy==2.4.1
 sqlalchemy
 pymysql
-stravalib==1.5
-cherrypy==18.9.0
+stravalib
+cherrypy
 certifi

--- a/setup.ini.dist
+++ b/setup.ini.dist
@@ -5,11 +5,6 @@ base =
 user = 
 # The password associated to the above user
 password = 
-# The following two tables are created within the local database
-# A table to store the list of bikes
-bikes_table = 
-# A table to store all your activities
-activities_table = 
 
 [strava]
 # The id of the client from `My Account/My Apps`
@@ -19,9 +14,9 @@ client_secret =
 # Do you want to retrieve red points for every activity. It induces one
 # extra http request per activity. Use "yes" or "no"
 with_points = no
-# Do you want to retrieve the description for every activity. It induces one
+# Do you want to retrieve the details for every activity. It induces one
 # extra http request per activity. Use "yes" or "no"
-with_description = no
+with_details = no
 
 [server]
 session_dir = /tmp/MyStrava


### PR DESCRIPTION
This PR is a major upgrade to use Stravalib-2.0.
Because of https://github.com/stravalib/stravalib#570, **importing new activities from Strava is still broken**. The fix is in the `main` branch but has not been released yet.


 Here is a list of major (and breaking) changes 

- The name of the tables for activities and gears are now hardcoded: `activities` and `gears`.
- A new field `sport_type` is added to the `Activity` model (table `activities`). It will replace `type` at some point and reflects the more detailed activity types introduced by Strava a few years ago. To update the table scheme, run

     ```
     ALTER TABLE activities ADD sport_type enum('AlpineSki', 'BackcountrySki', 'Badminton', 'Canoeing', 'Crossfit', 'EBikeRide', 'Elliptical', 'EMountainBikeRide', 'Golf', 'GravelRide', 'Handcycle', 'HighIntensityIntervalTraining', 'Hike', 'IceSkate', 'InlineSkate', 'Kayaking', 'Kitesurf', 'MountainBikeRide', 'NordicSki', 'Pickleball', 'Pilates', 'Racquetball', 'Ride', 'RockClimbing', 'RollerSki', 'Rowing', 'Run', 'Sail', 'Skateboard', 'Snowboard', 'Snowshoe', 'Soccer', 'Squash', 'StairStepper', 'StandUpPaddling', 'Surfing', 'Swim', 'TableTennis', 'Tennis', 'TrailRun', 'Velomobile', 'VirtualRide', 'VirtualRow', 'VirtualRun', 'Walk', 'WeightTraining', 'Wheelchair', 'Windsurf', 'Workout', 'Yoga');

     ALTER TABLE activities RENAME COLUMN type TO old_type;

     ALTER TABLE activities ADD type enum('AlpineSki', 'BackcountrySki', 'Canoeing', 'Crossfit', 'EBikeRide', 'Elliptical', 'Golf', 'Handcycle', 'Hike', 'IceSkate', 'InlineSkate', 'Kayaking', 'Kitesurf', 'NordicSki', 'Ride', 'RockClimbing', 'RollerSki', 'Rowing', 'Run', 'Sail', 'Skateboard', 'Snowboard', 'Snowshoe', 'Soccer', 'StairStepper', 'StandUpPaddling', 'Surfing', 'Swim', 'Velomobile', 'VirtualRide', 'VirtualRun', 'Walk', 'WeightTraining', 'Wheelchair', 'Windsurf', 'Workout', 'Yoga') AFTER calories;

     UPDATE activities SET type=old_type;

     ALTER TABLE activities DROP COLUMN old_type;
     ```
- To update the old activitties, already in the local database, call `http://127.0.0.1:8080/updatesporttype?trail_seuil=250`. The parameter `trail_seuil` is used to mark as trail runnning all running activities with more than a given amount of elevation.
- All type of activities are now imported in the app.
- The fronted is updated to work with `sport_type` instead of `type`.
